### PR TITLE
Lingvonomoj, morfologio, malgrandaj HTML-ŝanĝoj

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html> 
-    
-    <head> 
-        <meta http-equiv="Content-Type" content="text/html;charset=utf-8" > 
-        <title>{% block title %}La Simpla Vortaro de Esperanto{% endblock %}</title> 
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>{% block title %}La Simpla Vortaro de Esperanto{% endblock %}</title>
+        <meta name="description" content="La Simpla Vortaro estas interfaco por la difinoj de ReVo. Ĝi inkluzivas kelkajn helpilojn kaj simplan strukturon.">
 
         <link rel="stylesheet" type="text/css" href="/resources/style.css">
         <!--[if IE]>
@@ -16,17 +16,17 @@
               href="/resources/search.xml"
               title="La Simpla Vortaro" />
 
+        <meta property="og:type" content="website">
+        <meta property="og:title" content="{% block title %}La Simpla Vortaro de Esperanto{% endblock %}">
+        <meta property="og:description" content="La Simpla Vortaro estas interfaco por la difinoj de ReVo. Ĝi inkluzivas kelkajn helpilojn kaj simplan strukturon.">
     </head>
-    
-    <body> 
-
-        <img id="background" src="/resources/book.jpg" alt="background">
+    <body>
+        <img id="background" src="/resources/book.jpg" alt="">
 
         <div id="background-overlay">
         </div>
 
         <div id="everything">
-
             <div id="header">
                 <h1><a href="{% url 'index'%}">La Simpla Vortaro</a></h1>
             </div>
@@ -35,13 +35,12 @@
                 <form action="{% url 'search_word' %}" method="get">
                     <p>
                         <input type="text" value="{% block searchterm %}{% endblock %}"
-	                       name="s" id="search_box"
-                               placeholder="Entajpu vorton">
+                           name="s" id="search_box" placeholder="Entajpu vorton">
                     </p>
                     <p>
                         <button type="submit" value="Serĉi">Serĉi</button>
                         <button type="submit" name="rekte" value="jes">
-	                    Mi sentas min bonŝanca</button>
+                            Mi sentas min bonŝanca</button>
                     </p>
                 </form>
             </div>
@@ -53,31 +52,24 @@
                     |
                     <a href="{% url 'about_the_api' %}">API</a>
                     |
-                    <a href="http://lalingvisto.wordpress.com/">Blogo</a>
+                    <a href="https://lalingvisto.wordpress.com/">Blogo</a>
                 </p>
                 {% endblock %}
             </div>
-
         </div>
 
         <script type="text/javascript">
             document.getElementById('search_box').focus();
-        </script>
 
-        <script type="text/javascript"> 
-            
             var _gaq = _gaq || [];
             _gaq.push(['_setAccount', 'UA-11973220-3']);
             _gaq.push(['_trackPageview']);
-            
+
             (function() {
             var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
             ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
             var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
             })();
-            
         </script>
-
-    </body> 
-    
+    </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="eo" dir="ltr">
     <head>
         <meta charset="utf-8">
         <title>{% block title %}La Simpla Vortaro de Esperanto{% endblock %}</title>
@@ -17,7 +17,7 @@
               title="La Simpla Vortaro" />
 
         <meta property="og:type" content="website">
-        <meta property="og:title" content="{% block title %}La Simpla Vortaro de Esperanto{% endblock %}">
+        <meta property="og:title" content="La Simpla Vortaro de Esperanto">
         <meta property="og:description" content="La Simpla Vortaro estas interfaco por la difinoj de ReVo. Ĝi inkluzivas kelkajn helpilojn kaj simplan strukturon.">
     </head>
     <body>

--- a/vortaro/models.py
+++ b/vortaro/models.py
@@ -130,7 +130,7 @@ class Variant(models.Model):
     writing system.
 
     An example:
-    
+
     The variants of the word "aĉeti" will have include "aĉeti",
     "aĉetas", "aĉetu", "aĉetanta", "acxetis", "achetata" and so on.
 
@@ -140,7 +140,7 @@ class Variant(models.Model):
 
     def __unicode__(self):
         return self.variant
-    
+
 class Morpheme(models.Model):
     """A potential component of a word that has been put together. We
     generate morphemes in all three major writing systems, and also
@@ -150,8 +150,8 @@ class Morpheme(models.Model):
     manually with a null primary_word. No other Morphemes should be
     like this.
 
-    Note that the following words produce clashes: 
-    
+    Note that the following words produce clashes:
+
     sumo, haplo, nova, togo, vila, koto, metro, polo, alo --
     because they could be <word> or <word>o
 
@@ -219,42 +219,44 @@ class Translation(models.Model):
             'et': u'La estona', 'eu': u'La eŭska',
             'fa': u'La persa', 'fi': u'La finna',
             'fj': u'La fiĝia', 'fo': u'La feroa',
-            'fr': u'La franca', 'fy': u'La frisa',
-            'ga': u'La irlanda', 'gd': u'La gaela',
+            'fr': u'La franca', 'fy': u'La okcidentfrisa',
+            'ga': u'La irlanda', 'gd': u'La skotgaela',
             'gl': u'La galega', 'gn': u'La gvarania',
-            'grc': u'La malnovgreka', 'gu': u'La guĝarata',
-            'ha': u'La haŭsa', 'he': u'La hebrea',
-            'hi': u'La hinda', 'hr': u'La kroata',
-            'hu': u'La hungara', 'hy': u'La armena',
-            'ia': u'Interlingvao', 'id': u'La indonezia',
-            'ie': u'La okcidentala', 'ik': u'La eskima',
+            'goyu': u'La tajvana', 'grc': u'La malnovgreka',
+            'gu': u'La guĝarata', 'ha': u'La haŭsa',
+            'he': u'La hebrea', 'hi': u'La hinda',
+            'hr': u'La kroata', 'hu': u'La hungara',
+            'hy': u'La armena', 'ia': u'Interlingvao',
+            'id': u'La indonezia', 'ie': u'Okcidentalo',
+            'ik': u'La inupiaka', 'io': u'Ido',
             'is': u'La islanda', 'it': u'La itala',
-            'iu': u'La inuita', 'ja': u'La japana',
+            'iu': u'La inuktituta', 'ja': u'La japana',
             'jbo': u'Loĵbano', 'jw': u'La java',
-            'ka': u'La kartvela', 'kk': u'La kazaĥa',
-            'kl': u'La gronlanda', 'km': u'La kmera',
-            'kn': u'La kanara', 'ko': u'La korea',
-            'ks': u'La kaŝmira', 'ku': u'La kurda',
-            'ky': u'La kirgiza', 'la': u'La latina/scienca',
-            'lat': u'La malnovlatina', 'ln': u'La lingala',
-            'lo': u'La laŭa', 'lt': u'La litova',
-            'lv': u'La latva', 'mg': u'La malagasa',
-            'mi': u'La maoria', 'mk': u'La makedona',
-            'ml': u'La malajalama', 'mn': u'La mongola',
-            'mo': u'La moldava', 'mr': u'La marata',
-            'ms': u'La malaja', 'mt': u'La malta',
-            'my': u'La birma', 'na': u'La naura',
-            'ne': u'La nepala', 'nl': u'La nederlanda',
-            'no': u'La norvega', 'oc': u'La okcitana',
-            'om': u'La oroma', 'or': u'La orijo',
-            'os': u'La oseta', 'pa': u'La panĝaba',
-            'pl': u'La pola', 'ps': u'La paŝtua',
-            'pt': u'La portugala', 'qu': u'La keĉua',
-            'rm': u'La romanĉa', 'rn': u'La burunda',
-            'ro': u'La rumana', 'ru': u'La rusa',
-            'rw': u'La ruanda', 'sa': u'La sanskrita',
-            'sd': u'La sinda', 'sg': u'La sangoa',
-            'sh': u'La serbo-kroata', 'si': u'La sinhala',
+            'ka': u'La kartvela', 'kek': u'La kekĉia',
+            'kk': u'La kazaĥa', 'kl': u'La gronlanda',
+            'km': u'La kmera', 'kn': u'La kanara',
+            'ko': u'La korea', 'ks': u'La kaŝmira',
+            'ku': u'La kurda', 'ky': u'La kirgiza',
+            'la': u'Latineca nomo', 'lat': u'Latino',
+            'ln': u'La lingala', 'lo': u'La laŭa',
+            'lt': u'La litova', 'lv': u'La latva',
+            'mg': u'La malagasa', 'mi': u'La maoria',
+            'mk': u'La makedona', 'ml': u'La malajalama',
+            'mn': u'La mongola', 'mo': u'La moldava',
+            'mr': u'La marata', 'ms': u'La malaja',
+            'mt': u'La malta', 'my': u'La birma',
+            'na': u'La naura', 'ne': u'La nepala',
+            'nl': u'La nederlanda', 'no': u'La norvega',
+            'oc': u'La okcitana', 'om': u'La oroma',
+            'or': u'La odia', 'os': u'La oseta',
+            'pa': u'La panĝaba', 'pl': u'La pola',
+            'ps': u'La paŝtua', 'pt': u'La portugala',
+            'qu': u'La keĉua', 'rm': u'La romanĉa',
+            'rn': u'La burunda', 'ro': u'La rumana',
+            'ru': u'La rusa', 'rw': u'La ruanda',
+            'sa': u'Sanskrito', 'sd': u'La sinda',
+            'se': u'La nordsamea', 'sg': u'La sangoa',
+            'sh': u'La serbokroata', 'si': u'La sinhala',
             'sk': u'La slovaka', 'sl': u'La slovena',
             'sm': u'La samoa', 'sn': u'La ŝona',
             'so': u'La somala', 'sq': u'La albana',
@@ -268,10 +270,10 @@ class Translation(models.Model):
             'to': u'La tongaa', 'tp': u'Tokipono',
             'tr': u'La turka', 'ts': u'La conga',
             'tt': u'La tatara', 'tw': u'La akana',
-            'ug': u'La ujgura', 'uk': u'La ukrajna',
-            'ur': u'La urduo', 'uz': u'La uzbeka',
+            'ug': u'La ujgura', 'uk': u'La ukraina',
+            'ur': u'Urduo', 'uz': u'La uzbeka',
             'vi': u'La vjetnama', 'vo': u'Volapuko',
-            'wo': u'La volofa', 'xh': u'La ksosa',
+            'wo': u'La volofa', 'xh': u'La kosa',
             'yi': u'La jida', 'yo': u'La joruba',
             'za': u'La ĝuanga', 'zh': u'La ĉina',
             'zu': u'La zulua'}

--- a/vortaro/morphology.py
+++ b/vortaro/morphology.py
@@ -27,7 +27,7 @@ def split_verb(word):
     # infinitives
     if word.endswith('i'):
         # *i words that are not verbs:
-        pronouns = [u'mi', u'vi', u'li', u'ŝi', u'ĝi', u'oni', u'ili', u'si', u'ci']
+        pronouns = [u'ci', u'ĝi', u'ili', u'li', u'mi', u'ni', u'oni', u'ri', u'si', u'ŝi', u'vi']
         adverbs = [u'ĉi']
         exclamations = [u'ahi', u'fi']
         abbreviations = [u'ĥi'] # same as ĥio actually
@@ -159,10 +159,10 @@ def split_noun(word):
         exclamation = ['ho']
         # we list the prefices for completeness
         # although they arguably end '-'
-        affices = ['-o', 'bo-', 'geo-']
+        affixes = ['-o', 'bo-', 'geo-']
         conjunction = ['do']
         preposition = ['po']
-        if word in [exclamation + affices + conjunction + preposition]:
+        if word in [exclamation + affixes + conjunction + preposition]:
             return None
         else:
             return (word[:-1], 'o')
@@ -200,8 +200,8 @@ def split_adverb(word):
         particle = ['ne'] # vague category I know, but nothing else fits
         fixed_adverbs = ['tre']
         name = ['Kabe']
-        affix = ['tele-'] # again affices only for completeness
-        if word in (preposition + exclamation + conjunctions + 
+        affix = ['tele-'] # again affixes only for completeness
+        if word in (preposition + exclamation + conjunctions +
                     particle + fixed_adverbs + name + affix):
             return None
         else:
@@ -221,7 +221,7 @@ def split_adverb(word):
     return None
 
 def is_pronoun(word):
-    if word in ['mi', 'vi', 'li', u'ŝi', 'ni', 'ili', 'si', 'ci']:
+    if word in ['ci', 'ĝi', 'ili', 'li', 'mi', 'ni', 'oni', 'ri', 'si', 'ŝi', 'vi']:
         return True
 
     return False
@@ -410,7 +410,7 @@ def canonicalise_word(word):
 
     """
     word = word.strip()
-    
+
     # substitute ' if used, since e.g. vort' == vorto
     if word.endswith("'"):
         word = word[:-1] + 'o'


### PR DESCRIPTION
* Mi ĝisdatigis la liston de lingvonomoj, laŭ la lasta versio ĉe Reta Vortaro.
* Mi ĝisdatigis la liston de pronomoj en la morfologia skripto, laŭ la vortoj registritaj en Reta Vortaro.
* Kaj mi ankaŭ faris kelkajn malgrandajn ŝanĝojn al la ĉefa HTML-ŝablono.

Eble vi povus post apliki ĉi tiun tirpeton rekrei la datumbazon surbaze de la plej lasta dosiero:
http://reta-vortaro.de/tgz/revoxml_2020-03-27.zip